### PR TITLE
add map directory json

### DIFF
--- a/map_directory.json
+++ b/map_directory.json
@@ -1,0 +1,18 @@
+[
+    "EmptyMap",
+    "UT_Campus",
+    "AHG_Apartment",
+    "GDC1",
+    "GDC2",
+    "GDC3",
+    "GDC4",
+    "GDC5",
+    "GDC6",
+    "GDC7",
+    "GHC1",
+    "GHC2",
+    "GHC3",
+    "GHC5",
+    "GHC6",
+    "Airsim-Neighborhood"
+]


### PR DESCRIPTION
This is used by https://github.com/ut-amrl/robofleet_webviz/pull/10/commits to allow the robofleet webviz to display a list of available maps. This is done explicitly so that we have to "whitelist" maps, so that, for example, random old maps from MIT don't show up in the dropdown unnecessarily