### PR TITLE
Add a few v2 maps

### DIFF
--- a/AHG2/AHG2.navigation.json
+++ b/AHG2/AHG2.navigation.json
@@ -1,0 +1,96 @@
+{
+    "edges": [
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 1,
+            "s1_id": 2
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 2,
+            "s1_id": 1
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 2,
+            "s1_id": 3
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 3,
+            "s1_id": 2
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 1.0,
+            "max_speed": 2.0,
+            "s0_id": 4,
+            "s1_id": 5
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 1.0,
+            "max_speed": 2.0,
+            "s0_id": 4,
+            "s1_id": 3
+        }
+    ],
+    "nodes": [
+        {
+            "id": 0,
+            "loc": {
+                "x": 1.7000000476837158,
+                "y": 30.0
+            }
+        },
+        {
+            "id": 1,
+            "loc": {
+                "x": 12.069999694824219,
+                "y": 75.05000305175781
+            }
+        },
+        {
+            "id": 2,
+            "loc": {
+                "x": 12.069999694824219,
+                "y": 72.5999984741211
+            }
+        },
+        {
+            "id": 3,
+            "loc": {
+                "x": 8.069999694824219,
+                "y": 72.5999984741211
+            }
+        },
+        {
+            "id": 4,
+            "loc": {
+                "x": 5.374732971191406,
+                "y": 67.73062896728516
+            }
+        },
+        {
+            "id": 5,
+            "loc": {
+                "x": 2.6450064182281494,
+                "y": 62.31017303466797
+            }
+        }
+    ]
+}

--- a/AHG_Apartment/AHG_Apartment.navigation.json
+++ b/AHG_Apartment/AHG_Apartment.navigation.json
@@ -1,0 +1,860 @@
+{
+    "edges": [
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 1,
+            "s1_id": 2
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 1,
+            "s1_id": 3
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 1,
+            "s1_id": 20
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 1,
+            "s1_id": 17
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 2,
+            "s1_id": 1
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 2,
+            "s1_id": 6
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 2,
+            "s1_id": 7
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 3,
+            "s1_id": 1
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 3,
+            "s1_id": 4
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 3,
+            "s1_id": 5
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 3,
+            "s1_id": 17
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 4,
+            "s1_id": 3
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 4,
+            "s1_id": 13
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 4,
+            "s1_id": 15
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 4,
+            "s1_id": 17
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 5,
+            "s1_id": 3
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 5,
+            "s1_id": 6
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 5,
+            "s1_id": 12
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 6,
+            "s1_id": 2
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 6,
+            "s1_id": 5
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 6,
+            "s1_id": 8
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 7,
+            "s1_id": 2
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 7,
+            "s1_id": 8
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 7,
+            "s1_id": 9
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 8,
+            "s1_id": 6
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 8,
+            "s1_id": 7
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 9,
+            "s1_id": 7
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 9,
+            "s1_id": 10
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 10,
+            "s1_id": 9
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 10,
+            "s1_id": 11
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 11,
+            "s1_id": 10
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 12,
+            "s1_id": 5
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 12,
+            "s1_id": 13
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 12,
+            "s1_id": 25
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 13,
+            "s1_id": 4
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 13,
+            "s1_id": 12
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 13,
+            "s1_id": 14
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 13,
+            "s1_id": 25
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 14,
+            "s1_id": 13
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 14,
+            "s1_id": 15
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 14,
+            "s1_id": 25
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 15,
+            "s1_id": 4
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 15,
+            "s1_id": 14
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 15,
+            "s1_id": 17
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 16,
+            "s1_id": 18
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 16,
+            "s1_id": 19
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 16,
+            "s1_id": 17
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 16,
+            "s1_id": 20
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 17,
+            "s1_id": 1
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 17,
+            "s1_id": 3
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 17,
+            "s1_id": 4
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 17,
+            "s1_id": 15
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 17,
+            "s1_id": 16
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 17,
+            "s1_id": 20
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 17,
+            "s1_id": 18
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 18,
+            "s1_id": 16
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 18,
+            "s1_id": 17
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 18,
+            "s1_id": 19
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 19,
+            "s1_id": 16
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 19,
+            "s1_id": 18
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 19,
+            "s1_id": 20
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 20,
+            "s1_id": 1
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 20,
+            "s1_id": 16
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 20,
+            "s1_id": 17
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 20,
+            "s1_id": 19
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 21,
+            "s1_id": 25
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 21,
+            "s1_id": 22
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 21,
+            "s1_id": 23
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 22,
+            "s1_id": 21
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 22,
+            "s1_id": 24
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 22,
+            "s1_id": 23
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 23,
+            "s1_id": 21
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 23,
+            "s1_id": 22
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 23,
+            "s1_id": 24
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 23,
+            "s1_id": 25
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 24,
+            "s1_id": 22
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 24,
+            "s1_id": 23
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 24,
+            "s1_id": 25
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 25,
+            "s1_id": 12
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 25,
+            "s1_id": 13
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 25,
+            "s1_id": 14
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 25,
+            "s1_id": 21
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 25,
+            "s1_id": 23
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 25,
+            "s1_id": 24
+        }
+    ],
+    "nodes": [
+        {
+            "id": 0,
+            "loc": {
+                "x": 0.0,
+                "y": 0.0
+            }
+        },
+        {
+            "id": 1,
+            "loc": {
+                "x": -0.7009999752044678,
+                "y": -0.20028600096702576
+            }
+        },
+        {
+            "id": 2,
+            "loc": {
+                "x": 14.801400184631348,
+                "y": 2.277129888534546
+            }
+        },
+        {
+            "id": 3,
+            "loc": {
+                "x": -1.9809099435806274,
+                "y": 2.4260900020599365
+            }
+        },
+        {
+            "id": 4,
+            "loc": {
+                "x": -2.308300018310547,
+                "y": 4.063029766082764
+            }
+        },
+        {
+            "id": 5,
+            "loc": {
+                "x": 16.110300064086914,
+                "y": 5.533450126647949
+            }
+        },
+        {
+            "id": 6,
+            "loc": {
+                "x": 16.28459930419922,
+                "y": 3.731829881668091
+            }
+        },
+        {
+            "id": 7,
+            "loc": {
+                "x": 15.703399658203125,
+                "y": -1.731160044670105
+            }
+        },
+        {
+            "id": 8,
+            "loc": {
+                "x": 18.552000045776367,
+                "y": -0.11720199882984161
+            }
+        },
+        {
+            "id": 9,
+            "loc": {
+                "x": 11.24590015411377,
+                "y": -2.7116498947143555
+            }
+        },
+        {
+            "id": 10,
+            "loc": {
+                "x": 9.13539981842041,
+                "y": -4.209400177001953
+            }
+        },
+        {
+            "id": 11,
+            "loc": {
+                "x": 4.437910079956055,
+                "y": -3.5286099910736084
+            }
+        },
+        {
+            "id": 12,
+            "loc": {
+                "x": 19.308799743652344,
+                "y": 6.1727399826049805
+            }
+        },
+        {
+            "id": 13,
+            "loc": {
+                "x": 18.972200393676758,
+                "y": 7.85561990737915
+            }
+        },
+        {
+            "id": 14,
+            "loc": {
+                "x": 18.523399353027344,
+                "y": 9.482410430908203
+            }
+        },
+        {
+            "id": 15,
+            "loc": {
+                "x": -2.400439977645874,
+                "y": 5.667870044708252
+            }
+        },
+        {
+            "id": 16,
+            "loc": {
+                "x": -8.418439865112305,
+                "y": -1.4136199951171875
+            }
+        },
+        {
+            "id": 17,
+            "loc": {
+                "x": -6.21136999130249,
+                "y": 2.5275800228118896
+            }
+        },
+        {
+            "id": 18,
+            "loc": {
+                "x": -12.622400283813477,
+                "y": 1.3714900016784668
+            }
+        },
+        {
+            "id": 19,
+            "loc": {
+                "x": -11.413700103759766,
+                "y": -6.3007001876831055
+            }
+        },
+        {
+            "id": 20,
+            "loc": {
+                "x": -3.6364500522613525,
+                "y": -4.776770114898682
+            }
+        },
+        {
+            "id": 21,
+            "loc": {
+                "x": 26.70359992980957,
+                "y": -1.254040002822876
+            }
+        },
+        {
+            "id": 22,
+            "loc": {
+                "x": 32.60340118408203,
+                "y": -0.35100799798965454
+            }
+        },
+        {
+            "id": 23,
+            "loc": {
+                "x": 28.63010025024414,
+                "y": 4.465179920196533
+            }
+        },
+        {
+            "id": 24,
+            "loc": {
+                "x": 30.857500076293945,
+                "y": 9.762980461120605
+            }
+        },
+        {
+            "id": 25,
+            "loc": {
+                "x": 23.27199935913086,
+                "y": 8.498729705810547
+            }
+        }
+    ]
+}

--- a/UT_Campus/UT_Campus.navigation.json
+++ b/UT_Campus/UT_Campus.navigation.json
@@ -1,0 +1,1240 @@
+{
+    "edges": [
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 0,
+            "s1_id": 1
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 1,
+            "s1_id": 0
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 1,
+            "s1_id": 2
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 2,
+            "s1_id": 1
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 2,
+            "s1_id": 3
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 3,
+            "s1_id": 2
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 3,
+            "s1_id": 10
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 4,
+            "s1_id": 5
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 4,
+            "s1_id": 10
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 5,
+            "s1_id": 4
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 5,
+            "s1_id": 37
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 6,
+            "s1_id": 7
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 6,
+            "s1_id": 37
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 7,
+            "s1_id": 6
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 7,
+            "s1_id": 8
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 7,
+            "s1_id": 24
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 8,
+            "s1_id": 7
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 8,
+            "s1_id": 9
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 9,
+            "s1_id": 8
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 10,
+            "s1_id": 3
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 10,
+            "s1_id": 4
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 10,
+            "s1_id": 11
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 11,
+            "s1_id": 10
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 11,
+            "s1_id": 22
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 12,
+            "s1_id": 13
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 12,
+            "s1_id": 21
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 13,
+            "s1_id": 12
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 13,
+            "s1_id": 17
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 14,
+            "s1_id": 15
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 14,
+            "s1_id": 20
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 15,
+            "s1_id": 14
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 15,
+            "s1_id": 16
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 16,
+            "s1_id": 15
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 17,
+            "s1_id": 13
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 17,
+            "s1_id": 18
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 18,
+            "s1_id": 17
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 18,
+            "s1_id": 23
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 19,
+            "s1_id": 20
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 19,
+            "s1_id": 23
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 20,
+            "s1_id": 14
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 20,
+            "s1_id": 19
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 21,
+            "s1_id": 12
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 21,
+            "s1_id": 22
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 22,
+            "s1_id": 11
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 22,
+            "s1_id": 21
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 23,
+            "s1_id": 18
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 23,
+            "s1_id": 19
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 24,
+            "s1_id": 7
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 24,
+            "s1_id": 25
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 25,
+            "s1_id": 24
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 25,
+            "s1_id": 26
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 26,
+            "s1_id": 25
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 26,
+            "s1_id": 27
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 27,
+            "s1_id": 26
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 27,
+            "s1_id": 28
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 28,
+            "s1_id": 27
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 28,
+            "s1_id": 29
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 29,
+            "s1_id": 28
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 29,
+            "s1_id": 30
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 30,
+            "s1_id": 29
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 30,
+            "s1_id": 31
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 31,
+            "s1_id": 30
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 31,
+            "s1_id": 32
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 32,
+            "s1_id": 31
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 32,
+            "s1_id": 34
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 33,
+            "s1_id": 34
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 33,
+            "s1_id": 35
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 34,
+            "s1_id": 32
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 34,
+            "s1_id": 33
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 35,
+            "s1_id": 33
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 35,
+            "s1_id": 39
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 36,
+            "s1_id": 39
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 36,
+            "s1_id": 40
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 37,
+            "s1_id": 5
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 37,
+            "s1_id": 6
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 37,
+            "s1_id": 38
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 38,
+            "s1_id": 37
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 38,
+            "s1_id": 42
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 39,
+            "s1_id": 35
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 39,
+            "s1_id": 36
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 40,
+            "s1_id": 36
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 40,
+            "s1_id": 41
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 41,
+            "s1_id": 40
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 42,
+            "s1_id": 38
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 42,
+            "s1_id": 47
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 43,
+            "s1_id": 44
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 43,
+            "s1_id": 48
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 44,
+            "s1_id": 43
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 44,
+            "s1_id": 45
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 44,
+            "s1_id": 51
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 45,
+            "s1_id": 44
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 45,
+            "s1_id": 46
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 45,
+            "s1_id": 47
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 46,
+            "s1_id": 45
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 46,
+            "s1_id": 49
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 47,
+            "s1_id": 42
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 47,
+            "s1_id": 45
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 48,
+            "s1_id": 49
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 48,
+            "s1_id": 43
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 49,
+            "s1_id": 46
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 49,
+            "s1_id": 48
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 51,
+            "s1_id": 44
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 51,
+            "s1_id": 52
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 52,
+            "s1_id": 53
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 52,
+            "s1_id": 51
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 53,
+            "s1_id": 52
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 1.0,
+            "max_speed": 2.0,
+            "s0_id": 41,
+            "s1_id": 53
+        }
+    ],
+    "nodes": [
+        {
+            "id": 0,
+            "loc": {
+                "x": 131.4199981689453,
+                "y": -245.77000427246094
+            }
+        },
+        {
+            "id": 1,
+            "loc": {
+                "x": 131.75999450683594,
+                "y": -252.17999267578125
+            }
+        },
+        {
+            "id": 2,
+            "loc": {
+                "x": 84.0,
+                "y": -255.22000122070313
+            }
+        },
+        {
+            "id": 3,
+            "loc": {
+                "x": 74.19999694824219,
+                "y": -123.36000061035156
+            }
+        },
+        {
+            "id": 4,
+            "loc": {
+                "x": 71.7300033569336,
+                "y": -87.2699966430664
+            }
+        },
+        {
+            "id": 5,
+            "loc": {
+                "x": 68.69999694824219,
+                "y": -60.630001068115234
+            }
+        },
+        {
+            "id": 6,
+            "loc": {
+                "x": 3.2699999809265137,
+                "y": -60.970001220703125
+            }
+        },
+        {
+            "id": 7,
+            "loc": {
+                "x": -0.7699999809265137,
+                "y": -39.04999923706055
+            }
+        },
+        {
+            "id": 8,
+            "loc": {
+                "x": -28.09000015258789,
+                "y": -40.060001373291016
+            }
+        },
+        {
+            "id": 9,
+            "loc": {
+                "x": -30.110000610351563,
+                "y": -33.310001373291016
+            }
+        },
+        {
+            "id": 10,
+            "loc": {
+                "x": 72.83550262451172,
+                "y": -102.08999633789063
+            }
+        },
+        {
+            "id": 11,
+            "loc": {
+                "x": -102.36699676513672,
+                "y": -116.97000122070313
+            }
+        },
+        {
+            "id": 12,
+            "loc": {
+                "x": -142.6540069580078,
+                "y": -136.38800048828125
+            }
+        },
+        {
+            "id": 13,
+            "loc": {
+                "x": -135.78799438476563,
+                "y": -217.00799560546875
+            }
+        },
+        {
+            "id": 14,
+            "loc": {
+                "x": -182.96200561523438,
+                "y": -347.6820068359375
+            }
+        },
+        {
+            "id": 15,
+            "loc": {
+                "x": -118.30400085449219,
+                "y": -339.95098876953125
+            }
+        },
+        {
+            "id": 16,
+            "loc": {
+                "x": -119.18199920654297,
+                "y": -334.8550109863281
+            }
+        },
+        {
+            "id": 17,
+            "loc": {
+                "x": -134.197998046875,
+                "y": -238.16400146484375
+            }
+        },
+        {
+            "id": 18,
+            "loc": {
+                "x": -174.13800048828125,
+                "y": -243.9080047607422
+            }
+        },
+        {
+            "id": 19,
+            "loc": {
+                "x": -177.96299743652344,
+                "y": -306.5870056152344
+            }
+        },
+        {
+            "id": 20,
+            "loc": {
+                "x": -184.8730010986328,
+                "y": -323.18798828125
+            }
+        },
+        {
+            "id": 21,
+            "loc": {
+                "x": -135.94900512695313,
+                "y": -129.77200317382813
+            }
+        },
+        {
+            "id": 22,
+            "loc": {
+                "x": -123.04900360107422,
+                "y": -123.27300262451172
+            }
+        },
+        {
+            "id": 23,
+            "loc": {
+                "x": -176.5,
+                "y": -300.43701171875
+            }
+        },
+        {
+            "id": 24,
+            "loc": {
+                "x": 3.334290027618408,
+                "y": -33.52640151977539
+            }
+        },
+        {
+            "id": 25,
+            "loc": {
+                "x": 5.386300086975098,
+                "y": -28.01420021057129
+            }
+        },
+        {
+            "id": 26,
+            "loc": {
+                "x": 12.404000282287598,
+                "y": -25.46929931640625
+            }
+        },
+        {
+            "id": 27,
+            "loc": {
+                "x": 12.243599891662598,
+                "y": 0.15899600088596344
+            }
+        },
+        {
+            "id": 28,
+            "loc": {
+                "x": 16.12470054626465,
+                "y": 1.4099400043487549
+            }
+        },
+        {
+            "id": 29,
+            "loc": {
+                "x": 15.739800453186035,
+                "y": 17.704299926757813
+            }
+        },
+        {
+            "id": 30,
+            "loc": {
+                "x": 41.688899993896484,
+                "y": 18.73069953918457
+            }
+        },
+        {
+            "id": 31,
+            "loc": {
+                "x": 44.800201416015625,
+                "y": 19.564699172973633
+            }
+        },
+        {
+            "id": 32,
+            "loc": {
+                "x": 44.5015983581543,
+                "y": 59.904701232910156
+            }
+        },
+        {
+            "id": 33,
+            "loc": {
+                "x": 41.04819869995117,
+                "y": 72.47509765625
+            }
+        },
+        {
+            "id": 34,
+            "loc": {
+                "x": 41.35070037841797,
+                "y": 62.977901458740234
+            }
+        },
+        {
+            "id": 35,
+            "loc": {
+                "x": 46.39970016479492,
+                "y": 71.23500061035156
+            }
+        },
+        {
+            "id": 36,
+            "loc": {
+                "x": 51.44879913330078,
+                "y": 57.817298889160156
+            }
+        },
+        {
+            "id": 37,
+            "loc": {
+                "x": 59.285099029541016,
+                "y": -59.54090118408203
+            }
+        },
+        {
+            "id": 38,
+            "loc": {
+                "x": 67.48509979248047,
+                "y": -52.674198150634766
+            }
+        },
+        {
+            "id": 39,
+            "loc": {
+                "x": 50.63330078125,
+                "y": 62.407798767089844
+            }
+        },
+        {
+            "id": 40,
+            "loc": {
+                "x": 55.04119873046875,
+                "y": 54.43870162963867
+            }
+        },
+        {
+            "id": 41,
+            "loc": {
+                "x": 58.1255989074707,
+                "y": 57.61750030517578
+            }
+        },
+        {
+            "id": 42,
+            "loc": {
+                "x": 65.87200164794922,
+                "y": -2.930649995803833
+            }
+        },
+        {
+            "id": 43,
+            "loc": {
+                "x": 123.89800262451172,
+                "y": 27.542499542236328
+            }
+        },
+        {
+            "id": 44,
+            "loc": {
+                "x": 88.9103012084961,
+                "y": 26.00950050354004
+            }
+        },
+        {
+            "id": 45,
+            "loc": {
+                "x": 89.40630340576172,
+                "y": 7.523600101470947
+            }
+        },
+        {
+            "id": 46,
+            "loc": {
+                "x": 125.83699798583984,
+                "y": 9.507450103759766
+            }
+        },
+        {
+            "id": 47,
+            "loc": {
+                "x": 87.85469818115234,
+                "y": -1.3722599744796753
+            }
+        },
+        {
+            "id": 48,
+            "loc": {
+                "x": 146.85299682617188,
+                "y": 27.96339988708496
+            }
+        },
+        {
+            "id": 49,
+            "loc": {
+                "x": 147.52699279785156,
+                "y": 10.425000190734863
+            }
+        },
+        {
+            "id": 50,
+            "loc": {
+                "x": 122.56700134277344,
+                "y": 27.64430046081543
+            }
+        },
+        {
+            "id": 51,
+            "loc": {
+                "x": 70.31379699707031,
+                "y": 25.421100616455078
+            }
+        },
+        {
+            "id": 52,
+            "loc": {
+                "x": 68.24340057373047,
+                "y": 54.40589904785156
+            }
+        },
+        {
+            "id": 53,
+            "loc": {
+                "x": 66.09349822998047,
+                "y": 57.192901611328125
+            }
+        }
+    ]
+}

--- a/UT_Campus_With_Stairs/UT_Campus_With_Stairs.navigation.json
+++ b/UT_Campus_With_Stairs/UT_Campus_With_Stairs.navigation.json
@@ -1,0 +1,688 @@
+{
+    "edges": [
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 0,
+            "s1_id": 1
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 1,
+            "s1_id": 2
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 2,
+            "s1_id": 3
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 3,
+            "s1_id": 10
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 4,
+            "s1_id": 5
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 4,
+            "s1_id": 10
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 5,
+            "s1_id": 35
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 6,
+            "s1_id": 7
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 6,
+            "s1_id": 35
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 7,
+            "s1_id": 8
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 7,
+            "s1_id": 24
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 8,
+            "s1_id": 9
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 10,
+            "s1_id": 11
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 11,
+            "s1_id": 22
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 12,
+            "s1_id": 13
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 12,
+            "s1_id": 21
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 13,
+            "s1_id": 17
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 14,
+            "s1_id": 15
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 14,
+            "s1_id": 20
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 15,
+            "s1_id": 16
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 17,
+            "s1_id": 18
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 18,
+            "s1_id": 23
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 19,
+            "s1_id": 20
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 19,
+            "s1_id": 23
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 21,
+            "s1_id": 22
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 24,
+            "s1_id": 25
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 25,
+            "s1_id": 26
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 26,
+            "s1_id": 27
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 27,
+            "s1_id": 28
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 28,
+            "s1_id": 29
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 29,
+            "s1_id": 43
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 30,
+            "s1_id": 32
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 30,
+            "s1_id": 43
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 31,
+            "s1_id": 32
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 31,
+            "s1_id": 33
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 33,
+            "s1_id": 38
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 34,
+            "s1_id": 38
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 34,
+            "s1_id": 39
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 35,
+            "s1_id": 36
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 36,
+            "s1_id": 41
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 37,
+            "s1_id": 42
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 39,
+            "s1_id": 40
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 10.0,
+            "max_speed": 50.0,
+            "s0_id": 41,
+            "s1_id": 42
+        },
+        {
+            "has_door": false,
+            "has_stairs": true,
+            "max_clearance": 1.0,
+            "max_speed": 0.5,
+            "s0_id": 45,
+            "s1_id": 43
+        },
+        {
+            "has_door": false,
+            "has_stairs": false,
+            "max_clearance": 1.0,
+            "max_speed": 2.0,
+            "s0_id": 45,
+            "s1_id": 44
+        }
+    ],
+    "nodes": [
+        {
+            "id": 0,
+            "loc": {
+                "x": 131.4199981689453,
+                "y": -245.77000427246094
+            }
+        },
+        {
+            "id": 1,
+            "loc": {
+                "x": 131.75999450683594,
+                "y": -252.17999267578125
+            }
+        },
+        {
+            "id": 2,
+            "loc": {
+                "x": 84.0,
+                "y": -255.22000122070313
+            }
+        },
+        {
+            "id": 3,
+            "loc": {
+                "x": 74.19999694824219,
+                "y": -123.36000061035156
+            }
+        },
+        {
+            "id": 4,
+            "loc": {
+                "x": 71.7300033569336,
+                "y": -87.2699966430664
+            }
+        },
+        {
+            "id": 5,
+            "loc": {
+                "x": 68.69999694824219,
+                "y": -60.630001068115234
+            }
+        },
+        {
+            "id": 6,
+            "loc": {
+                "x": 3.2699999809265137,
+                "y": -60.970001220703125
+            }
+        },
+        {
+            "id": 7,
+            "loc": {
+                "x": -0.7699999809265137,
+                "y": -39.04999923706055
+            }
+        },
+        {
+            "id": 8,
+            "loc": {
+                "x": -28.09000015258789,
+                "y": -40.060001373291016
+            }
+        },
+        {
+            "id": 9,
+            "loc": {
+                "x": -30.110000610351563,
+                "y": -33.310001373291016
+            }
+        },
+        {
+            "id": 10,
+            "loc": {
+                "x": 72.83550262451172,
+                "y": -102.08999633789063
+            }
+        },
+        {
+            "id": 11,
+            "loc": {
+                "x": -102.36699676513672,
+                "y": -116.97000122070313
+            }
+        },
+        {
+            "id": 12,
+            "loc": {
+                "x": -142.6540069580078,
+                "y": -136.38800048828125
+            }
+        },
+        {
+            "id": 13,
+            "loc": {
+                "x": -135.78799438476563,
+                "y": -217.00799560546875
+            }
+        },
+        {
+            "id": 14,
+            "loc": {
+                "x": -182.96200561523438,
+                "y": -347.6820068359375
+            }
+        },
+        {
+            "id": 15,
+            "loc": {
+                "x": -118.30400085449219,
+                "y": -339.95098876953125
+            }
+        },
+        {
+            "id": 16,
+            "loc": {
+                "x": -119.18199920654297,
+                "y": -334.8550109863281
+            }
+        },
+        {
+            "id": 17,
+            "loc": {
+                "x": -134.197998046875,
+                "y": -238.16400146484375
+            }
+        },
+        {
+            "id": 18,
+            "loc": {
+                "x": -174.13800048828125,
+                "y": -243.9080047607422
+            }
+        },
+        {
+            "id": 19,
+            "loc": {
+                "x": -177.96299743652344,
+                "y": -306.5870056152344
+            }
+        },
+        {
+            "id": 20,
+            "loc": {
+                "x": -184.8730010986328,
+                "y": -323.18798828125
+            }
+        },
+        {
+            "id": 21,
+            "loc": {
+                "x": -135.94900512695313,
+                "y": -129.77200317382813
+            }
+        },
+        {
+            "id": 22,
+            "loc": {
+                "x": -123.04900360107422,
+                "y": -123.27300262451172
+            }
+        },
+        {
+            "id": 23,
+            "loc": {
+                "x": -176.5,
+                "y": -300.43701171875
+            }
+        },
+        {
+            "id": 24,
+            "loc": {
+                "x": 3.334290027618408,
+                "y": -33.52640151977539
+            }
+        },
+        {
+            "id": 25,
+            "loc": {
+                "x": 5.386300086975098,
+                "y": -28.01420021057129
+            }
+        },
+        {
+            "id": 26,
+            "loc": {
+                "x": 12.404000282287598,
+                "y": -25.46929931640625
+            }
+        },
+        {
+            "id": 27,
+            "loc": {
+                "x": 12.243599891662598,
+                "y": 0.15899600088596344
+            }
+        },
+        {
+            "id": 28,
+            "loc": {
+                "x": 16.12470054626465,
+                "y": 0.9599400162696838
+            }
+        },
+        {
+            "id": 29,
+            "loc": {
+                "x": 15.739800453186035,
+                "y": 17.704299926757813
+            }
+        },
+        {
+            "id": 30,
+            "loc": {
+                "x": 44.527198791503906,
+                "y": 60.30979919433594
+            }
+        },
+        {
+            "id": 31,
+            "loc": {
+                "x": 41.04819869995117,
+                "y": 72.47509765625
+            }
+        },
+        {
+            "id": 32,
+            "loc": {
+                "x": 41.381500244140625,
+                "y": 63.162498474121094
+            }
+        },
+        {
+            "id": 33,
+            "loc": {
+                "x": 46.39970016479492,
+                "y": 71.23500061035156
+            }
+        },
+        {
+            "id": 34,
+            "loc": {
+                "x": 51.44879913330078,
+                "y": 57.817298889160156
+            }
+        },
+        {
+            "id": 35,
+            "loc": {
+                "x": 59.285099029541016,
+                "y": -59.54090118408203
+            }
+        },
+        {
+            "id": 36,
+            "loc": {
+                "x": 67.48509979248047,
+                "y": -52.674198150634766
+            }
+        },
+        {
+            "id": 37,
+            "loc": {
+                "x": 93.57949829101563,
+                "y": 7.261940002441406
+            }
+        },
+        {
+            "id": 38,
+            "loc": {
+                "x": 50.63330078125,
+                "y": 62.407798767089844
+            }
+        },
+        {
+            "id": 39,
+            "loc": {
+                "x": 55.04119873046875,
+                "y": 54.43870162963867
+            }
+        },
+        {
+            "id": 40,
+            "loc": {
+                "x": 58.1255989074707,
+                "y": 57.61750030517578
+            }
+        },
+        {
+            "id": 41,
+            "loc": {
+                "x": 65.87200164794922,
+                "y": -2.930649995803833
+            }
+        },
+        {
+            "id": 42,
+            "loc": {
+                "x": 88.9845962524414,
+                "y": -2.039180040359497
+            }
+        },
+        {
+            "id": 43,
+            "loc": {
+                "x": 44.837799072265625,
+                "y": 17.927400588989258
+            }
+        },
+        {
+            "id": 44,
+            "loc": {
+                "x": 90.88510131835938,
+                "y": 19.02239990234375
+            }
+        },
+        {
+            "id": 45,
+            "loc": {
+                "x": 53.37141799926758,
+                "y": 15.979456901550293
+            }
+        }
+    ]
+}


### PR DESCRIPTION
This migrates some of the more "commonly used" maps to v2. Basically this just consists of running vector-display's `./bin/map-upgrade`, so any maps that folks need to use in the future can be easily upgraded using that script from now on